### PR TITLE
Lamia fixes/tweaks.

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -425,7 +425,7 @@
 /obj/item/weapon/weldingtool/attack(var/atom/A, var/mob/living/user, var/def_zone)
 	if(ishuman(A) && user.a_intent == I_HELP)
 		var/mob/living/carbon/human/H = A
-		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
+		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
 
 		if(!S || !(S.status & ORGAN_ROBOT))
 			return ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -457,3 +457,9 @@
 	if(isSynthetic())
 		return 0
 	return !(species.flags & NO_PAIN)
+
+/mob/living/carbon/return_air_for_internal_lifeform()
+	var/datum/gas_mixture/GM = new /datum/gas_mixture
+	GM.adjust_multi("oxygen", MOLES_O2STANDARD, "nitrogen", MOLES_N2STANDARD)
+	GM.temperature = bodytemperature
+	return GM

--- a/code/modules/mob/living/carbon/human/human_powers.dm
+++ b/code/modules/mob/living/carbon/human/human_powers.dm
@@ -95,6 +95,10 @@
 			if(M in stomach_contents)
 				stomach_contents.Remove(M)
 				M.loc = loc
+				if(iscarbon(loc))
+					var/mob/living/carbon/C = loc
+					if(src in C.stomach_contents)
+						C.stomach_contents += M
 		src.visible_message("\red <B>[src] hurls out the contents of their stomach!</B>")
 	return
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1375,19 +1375,25 @@
 
 /mob/living/carbon/human/handle_stomach()
 	spawn(0)
-		for(var/mob/living/M in stomach_contents)
-			if(M.loc != src)
-				stomach_contents.Remove(M)
+		for(var/A in stomach_contents)
+			var/mob/living/M = A
+			if(!istype(M))
+				stomach_contents -= A
 				continue
-			if(istype(M, /mob/living/carbon) && stat != DEAD)
-				if(M.stat == DEAD)
-					if(species.gluttonous < 3)
-						qdel(M)
-					continue
-				if(air_master.current_cycle % 3 == 1)
-					if(!(M.status_flags & GODMODE))
-						M.adjustBruteLoss(5)
-					nutrition += 10
+			if(M.loc != src)
+				stomach_contents -= M
+				continue
+			if(stat == DEAD)
+				return
+			if(M.stat == DEAD)
+				if(species.gluttonous < 3 || M.mob_size <= MOB_SMALL)
+					qdel(M)
+					stomach_contents -= M
+				continue
+			if(air_master.current_cycle % 3 == 1)
+				if(!(M.status_flags & GODMODE))
+					M.adjustBruteLoss(5)
+				nutrition += M.mob_size / 2
 
 /mob/living/carbon/human/proc/handle_changeling()
 	if(mind && mind.changeling)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -8,7 +8,7 @@
 		return
 	if(!loc)
 		return
-	var/datum/gas_mixture/environment = loc.return_air()
+	var/datum/gas_mixture/environment = loc.return_air_for_internal_lifeform()
 
 	if(stat != DEAD)
 		//Breathing, if applicable

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -46,7 +46,7 @@
 /datum/sprite_accessory/hair
 
 	icon = 'icons/mob/Human_face.dmi'	  // default icon for all hairs
-	species_allowed = list("Human","Unathi","Akula")
+	species_allowed = list("Human","Unathi","Akula", "Lamia")
 
 	bald
 		name = "Bald"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -499,7 +499,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 /obj/item/stack/cable_coil/attack(var/atom/A, var/mob/living/user, var/def_zone)
 	if(ishuman(A) && user.a_intent == I_HELP)
 		var/mob/living/carbon/human/H = A
-		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
+		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
 
 		if(!S || !(S.status & ORGAN_ROBOT))
 			return ..()


### PR DESCRIPTION
- Fixes
  - Lamia hair styles work again.
  - Welders/cables will repair mechanical lamia tails properly.
  - Regurgitating while inside another mob will add the mob you have regurgitated to that mob's stomach_contents, to avoid any "oh god i'm stuck" bugs.
- handle_stomach()
  - Anything that isn't a mob in stomach_contents will be removed (this
    includes nulls)
  - Anything that is mob_size MOB_SMALL or smaller will always be qdelled
    when dead, regardless of species.gluttonous.
  - Nutrition is now based on 1/2 of M.mob_size. This means a mouse will
    give 0.5 nutrition every 4 ticks, a monkey will give 5 nutrition per 4
    ticks, and a human will give 10 nutrition per 4 ticks.
  - Mobs are properly removed from stomach_contents when deleted.
- carbon/return_air_for_internal_lifeform()
  - carbon/return_air_for_internal_lifeform() will now return a gas
    mixture that is 1 atmosphere of a 21/79 mix of oxy/nitro, with the
    temperature being their body temperature.
    - This means that being inside of a mob while it's in a dangerous area
      will protect you if that mob's temperature is stable.
    - Intention is to give lamias a use beyond "traitor shennagin race."
  - handle_enviroment now uses loc.return_air_for_internal_lifeform(), as
    almost all uses of it still result in return_air() being called.
