### PR TITLE
Give again, I meant to say yes!

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -15,7 +15,7 @@
 		src << "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>"
 		return
 
-	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"No","Yes") == "No")
+	if(alert(target,"[src] wants to give you \a [I]. Will you accept it?",,"Yes","No") == "No")
 		target.visible_message("<span class='notice'>\The [src] tried to hand \the [I] to \the [target], \
 		but \the [target] didn't want it.</span>")
 		return


### PR DESCRIPTION
I've been noticing a high prevalence of people accidentally clicking "No" on give requests. I get why the coder who originally did this switched the buttons around: The alert proc gives you no control over which button is highlighted, and it's typically good GUI practice that "No"/"Cancel" is always the highlighted option. But it's just not natural that "No" is on the left and "Yes" is on the right. I personally think it raises more problems than it solves.

Here is my humble proposal to change it back.
